### PR TITLE
feature(Remote File Storage) Allow storage of remote files

### DIFF
--- a/lib/arc/actions/store.ex
+++ b/lib/arc/actions/store.ex
@@ -17,10 +17,7 @@ defmodule Arc.Actions.Store do
   # Private
   #
 
-  defp put(_definition, {{:error, _msg}, _scope}) do
-    {:error, :invalid_file}
-  end
-
+  defp put(_definition, { error = {:error, _msg}, _scope}), do: error
   defp put(definition, {%Arc.File{}=file, scope}) do
     case definition.validate({file, scope}) do
       true -> put_versions(definition, {file, scope})

--- a/lib/arc/file.ex
+++ b/lib/arc/file.ex
@@ -12,23 +12,31 @@ defmodule Arc.File do
     Path.join(System.tmp_dir, file_name)
   end
 
+  # Given a remote file
+  def new(remote_path = "http" <> _) do
+    case save_file(remote_path) do
+      {:ok, local_path} -> %Arc.File{path: local_path, file_name: Path.basename(remote_path)}
+      :error -> {:error, :invalid_file_path}
+    end
+  end
+
   # Accepts a path
   def new(path) when is_binary(path) do
     case File.exists?(path) do
-      true -> %Arc.File{ path: path, file_name: Path.basename(path) }
-      false -> {:error, :no_file}
+      true -> %Arc.File{path: path, file_name: Path.basename(path)}
+      false -> {:error, :invalid_file_path}
     end
   end
 
   def new(%{filename: filename, binary: binary}) do
-    %Arc.File{ binary: binary, file_name: Path.basename(filename) }
+    %Arc.File{binary: binary, file_name: Path.basename(filename)}
   end
 
   # Accepts a map conforming to %Plug.Upload{} syntax
   def new(%{filename: filename, path: path}) do
     case File.exists?(path) do
-      true -> %Arc.File{ path: path, file_name: filename }
-      false -> {:error, :no_file}
+      true -> %Arc.File{path: path, file_name: filename}
+      false -> {:error, :invalid_file_path}
     end
   end
 
@@ -43,5 +51,32 @@ defmodule Arc.File do
       file_name: file.file_name,
       path: path
     }
+  end
+
+  defp save_file(remote_path) when is_binary(remote_path) do
+    local_path =
+      generate_temporary_path()
+      |> Kernel.<>(Path.extname(remote_path))
+
+    case save_temp_file(local_path, remote_path) do
+      :ok -> {:ok, local_path}
+      _   -> :error
+    end
+  end
+
+  defp save_temp_file(local_path, remote_path) do
+    remote_file = get_remote_path(remote_path)
+
+    case remote_file do
+      {:ok, body} -> File.write(local_path, body)
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp get_remote_path(remote_path) do
+    case HTTPoison.get(remote_path) do
+      {:ok, %{status_code: 200, body: body}} -> {:ok, body}
+      other -> {:error, :invalid_file_path}
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -30,22 +30,23 @@ defmodule Arc.Mixfile do
   def application do
     [
       applications: [
-        :logger
+        :logger,
+        :httpoison,
       ] ++ applications(Mix.env)
     ]
   end
 
-  def applications(:test), do: [:ex_aws, :poison, :hackney]
+  def applications(:test), do: [:ex_aws, :poison]
   def applications(_), do: []
 
   defp deps do
     [
+      {:httpoison, "~> 0.8"}, # Required for downloading remote files
       {:ex_aws, "~> 1.0.0-rc.3", optional: true},
       {:mock, "~> 0.1.1", only: :test},
       {:ex_doc, "~> 0.14", only: :dev},
 
       # If using Amazon S3:
-      {:hackney, "~> 1.5", optional: true},
       {:poison, "~> 2.0", optional: true},
       {:sweet_xml, "~> 0.5", optional: true}
     ]


### PR DESCRIPTION
Allows passing in a remote url to an attachment, which Arc will download and store in your preferred storage location.

Usage:

```
Avatar.store("https://example.com/image.png") #=> {:ok, "image.png"}
```
