### PR TITLE
fix(Arc.Storage.Local): allow slashes in filename

### DIFF
--- a/lib/arc/storage/local.ex
+++ b/lib/arc/storage/local.ex
@@ -1,8 +1,9 @@
 defmodule Arc.Storage.Local do
   def put(definition, version, {file, scope}) do
     destination_dir = definition.storage_dir(version, {file, scope})
-    File.mkdir_p(destination_dir)
-    {:ok, _} = File.copy(file.path, Path.join(destination_dir, file.file_name))
+    path = Path.join(destination_dir, file.file_name)
+    path |> Path.dirname() |> File.mkdir_p()
+    {:ok, _} = File.copy(file.path, path)
     file.file_name
   end
 

--- a/test/storage/local_test.exs
+++ b/test/storage/local_test.exs
@@ -27,15 +27,15 @@ defmodule ArcTest.Storage.Local do
   test "put, delete, get" do
     assert "original-image.png" == Arc.Storage.Local.put(DummyDefinition, :original, {Arc.File.new(%{filename: "original-image.png", path: @img}), nil})
     assert "1/thumb-image.png" == Arc.Storage.Local.put(DummyDefinition, :thumb, {Arc.File.new(%{filename: "1/thumb-image.png", path: @img}), nil})
-    assert true == File.exists?("arctest/uploads/original-image.png")
-    assert true == File.exists?("arctest/uploads/1/thumb-image.png")
 
+    assert File.exists?("arctest/uploads/original-image.png")
+    assert File.exists?("arctest/uploads/1/thumb-image.png")
     assert "arctest/uploads/original-image.png" == DummyDefinition.url("image.png", :original)
     assert "arctest/uploads/1/thumb-image.png" == DummyDefinition.url("1/image.png", :thumb)
 
     Arc.Storage.Local.delete(DummyDefinition, :original, {%{file_name: "image.png"}, nil})
     Arc.Storage.Local.delete(DummyDefinition, :thumb, {%{file_name: "image.png"}, nil})
-    assert false == File.exists?("arctest/uploads/original-image.png")
-    assert false == File.exists?("arctest/uploads/1/thumb-image.png")
+    refute File.exists?("arctest/uploads/original-image.png")
+    refute File.exists?("arctest/uploads/1/thumb-image.png")
   end
 end

--- a/test/storage/local_test.exs
+++ b/test/storage/local_test.exs
@@ -4,6 +4,10 @@ defmodule ArcTest.Storage.Local do
 
   setup_all do
     File.mkdir_p("arctest/uploads")
+
+    on_exit fn ->
+      File.rm_rf("arctest/uploads")
+    end
   end
 
 
@@ -16,20 +20,22 @@ defmodule ArcTest.Storage.Local do
     def __versions, do: [:original, :thumb]
     def storage_dir(_, _), do: "arctest/uploads"
     def __storage, do: Arc.Storage.Local
-    def filename(version, {file, _}), do: "#{version}-#{Path.basename(file.file_name, Path.extname(file.file_name))}"
+    def filename(:original, {file, _}), do: "original-#{Path.basename(file.file_name, Path.extname(file.file_name))}"
+    def filename(:thumb, {file, _}), do: "1/thumb-#{Path.basename(file.file_name, Path.extname(file.file_name))}"
   end
 
   test "put, delete, get" do
     assert "original-image.png" == Arc.Storage.Local.put(DummyDefinition, :original, {Arc.File.new(%{filename: "original-image.png", path: @img}), nil})
-    assert "thumb-image.png" == Arc.Storage.Local.put(DummyDefinition, :thumb, {Arc.File.new(%{filename: "thumb-image.png", path: @img}), nil})
+    assert "1/thumb-image.png" == Arc.Storage.Local.put(DummyDefinition, :thumb, {Arc.File.new(%{filename: "1/thumb-image.png", path: @img}), nil})
     assert true == File.exists?("arctest/uploads/original-image.png")
-    assert true == File.exists?("arctest/uploads/thumb-image.png")
+    assert true == File.exists?("arctest/uploads/1/thumb-image.png")
 
     assert "arctest/uploads/original-image.png" == DummyDefinition.url("image.png", :original)
-    assert "arctest/uploads/thumb-image.png" == DummyDefinition.url("image.png", :thumb)
+    assert "arctest/uploads/1/thumb-image.png" == DummyDefinition.url("1/image.png", :thumb)
 
     Arc.Storage.Local.delete(DummyDefinition, :original, {%{file_name: "image.png"}, nil})
     Arc.Storage.Local.delete(DummyDefinition, :thumb, {%{file_name: "image.png"}, nil})
     assert false == File.exists?("arctest/uploads/original-image.png")
+    assert false == File.exists?("arctest/uploads/1/thumb-image.png")
   end
 end


### PR DESCRIPTION
S3 allows filenames to have slashes such as:

 > uploads/foo/bar/baz/image.png

The Local storage now supports this by combining the upload directory
and filename prior to saving the file.