### PR TITLE
Handle imagemagick exit codes

### DIFF
--- a/lib/arc/exceptions.ex
+++ b/lib/arc/exceptions.ex
@@ -1,0 +1,15 @@
+defmodule Arc.ConvertError do
+  defexception [:message]
+
+  def exception(opts) do
+    message = Keyword.fetch!(opts, :message)
+    exit_code = Keyword.fetch!(opts, :exit_code)
+
+    msg = """
+    Convert exited unsuccessfully with exit code #{exit_code}:
+    #{message}
+    """
+
+    %__MODULE__{message: msg}
+  end
+end

--- a/lib/arc/transformations/convert.ex
+++ b/lib/arc/transformations/convert.ex
@@ -5,8 +5,14 @@ defmodule Arc.Transformations.Convert do
     System.cmd("convert",
       ~w(#{file.path} #{args} #{String.replace(new_path, " ", "\\ ")}),
       stderr_to_stdout: true)
+    |> handle_exit_code
 
     %Arc.File{file | path: new_path}
+  end
+
+  defp handle_exit_code({_, 0}), do: :ok
+  defp handle_exit_code({error_message, exit_code}) do
+    raise Arc.ConvertError, message: error_message, exit_code: exit_code
   end
 
   defp temp_path do

--- a/test/processor_test.exs
+++ b/test/processor_test.exs
@@ -12,6 +12,16 @@ defmodule ArcTest.Processor do
     def __versions, do: [:original, :thumb]
   end
 
+  defmodule BrokenDefinition do
+    use Arc.Actions.Store
+    use Arc.Definition.Storage
+
+    def validate({file, _}), do: String.ends_with?(file.file_name, ".png")
+    def transform(:original, _), do: {:noaction}
+    def transform(:thumb, _), do: {:convert, "-strip -invalidTransformation 10x10"}
+    def __versions, do: [:original, :thumb]
+  end
+
   test "returns the original path for {:noaction} transformations" do
     assert Arc.Processor.process(DummyDefinition, :original, {Arc.File.new(@img), nil}).path == @img
   end
@@ -22,6 +32,12 @@ defmodule ArcTest.Processor do
     assert "128x128" == geometry(@img) #original file untouched
     assert "10x10" == geometry(new_file.path)
     cleanup(new_file.path)
+  end
+
+  test "raises an error in an invalid transformation" do
+    assert_raise Arc.ConvertError, ~r"unrecognized option", fn ->
+      Arc.Processor.process(BrokenDefinition, :thumb, {Arc.File.new(@img), nil})
+    end
   end
 
   defp geometry(path) do


### PR DESCRIPTION
Raises `Arc.ConvertError` if given invalid options to `convert`.