### PR TITLE
expose ExAws errors on uploads to S3

### DIFF
--- a/lib/arc/storage/s3.ex
+++ b/lib/arc/storage/s3.ex
@@ -7,7 +7,6 @@ defmodule Arc.Storage.S3 do
     binary = File.read!(file.path)
     acl = definition.acl(version, {file, scope})
     ExAws.S3.put_object(bucket, s3_key, binary, [acl: acl])
-    file.file_name
   end
 
   def url(definition, version, file_and_scope, options \\ []) do

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,7 @@ defmodule Arc.Mixfile do
   defp deps do
     [
       {:ex_aws,    "~> 0.4.10", optional: true},
+      {:poison,    "~> 1.2",    optional: true},
       {:httpoison, "~> 0.7",    optional: true},
       {:mock,      "~> 0.1.1",  only: :test}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -6,4 +6,5 @@
   "meck": {:hex, :meck, "0.8.2"},
   "mimerl": {:hex, :mimerl, "1.0.2"},
   "mock": {:hex, :mock, "0.1.1"},
+  "poison": {:hex, :poison, "1.5.0"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}

--- a/test/actions/store_test.exs
+++ b/test/actions/store_test.exs
@@ -21,26 +21,32 @@ defmodule ArcTest.Actions.Store do
   end
 
   test "single binary argument is interpreted as file path" do
-    with_mock Arc.Storage.S3, [put: fn(DummyDefinition, _, {%{file_name: "image.png", path: @img}, nil}) -> :ok end] do
+    with_mock Arc.Storage.S3, [put: fn(DummyDefinition, _, {%{file_name: "image.png", path: @img}, nil}) -> {:ok, "resp"} end] do
       assert DummyDefinition.store(@img) == {:ok, "image.png"}
     end
   end
 
   test "two-tuple argument interpreted as path and scope" do
-    with_mock Arc.Storage.S3, [put: fn(DummyDefinition, _, {%{file_name: "image.png", path: @img}, :scope}) -> :ok end] do
+    with_mock Arc.Storage.S3, [put: fn(DummyDefinition, _, {%{file_name: "image.png", path: @img}, :scope}) -> {:ok, "resp"} end] do
       assert DummyDefinition.store({@img, :scope}) == {:ok, "image.png"}
     end
   end
 
   test "map with a filename and path" do
-    with_mock Arc.Storage.S3, [put: fn(DummyDefinition, _, {%{file_name: "image.png", path: @img}, nil}) -> :ok end] do
+    with_mock Arc.Storage.S3, [put: fn(DummyDefinition, _, {%{file_name: "image.png", path: @img}, nil}) -> {:ok, "resp"} end] do
       assert DummyDefinition.store(%{filename: "image.png", path: @img}) == {:ok, "image.png"}
     end
   end
 
   test "two-tuple with Plug.Upload and a scope" do
-    with_mock Arc.Storage.S3, [put: fn(DummyDefinition, _, {%{file_name: "image.png", path: @img}, :scope}) -> :ok end] do
+    with_mock Arc.Storage.S3, [put: fn(DummyDefinition, _, {%{file_name: "image.png", path: @img}, :scope}) -> {:ok, "resp"} end] do
       assert DummyDefinition.store({%{filename: "image.png", path: @img}, :scope}) == {:ok, "image.png"}
+    end
+  end
+
+  test "error from ExAws on upload to S3" do
+    with_mock Arc.Storage.S3, [put: fn(DummyDefinition, _, {%{file_name: "image.png", path: @img}, :scope}) -> {:error, {:http_error, 404, "XML"}} end] do
+      assert DummyDefinition.store({%{filename: "image.png", path: @img}, :scope}) == {:error, [{:http_error, 404, "XML"}, {:http_error, 404, "XML"}]}
     end
   end
 

--- a/test/storage/s3_test.exs
+++ b/test/storage/s3_test.exs
@@ -38,7 +38,7 @@ defmodule ArcTest.Storage.S3 do
   @tag :s3
   test "public put and get" do
     #put the image as public
-    assert "image.png" == Arc.Storage.S3.put(DummyDefinition, :original, {Arc.File.new(@img), nil})
+    assert :ok == Arc.Storage.S3.put(DummyDefinition, :original, {Arc.File.new(@img), nil}) |> elem(0)
 
     #get a url to the image
     url = Arc.Storage.S3.url(DummyDefinition, :original, {Arc.File.new(@img), nil})
@@ -57,7 +57,7 @@ defmodule ArcTest.Storage.S3 do
   @tag :s3
   test "private put and signed get" do
     #put the image as private
-    assert "image.png" == Arc.Storage.S3.put(DummyDefinition, :private, {Arc.File.new(@img), nil})
+    assert :ok == Arc.Storage.S3.put(DummyDefinition, :private, {Arc.File.new(@img), nil}) |> elem(0)
 
     #get a url to the image
     url = Arc.Storage.S3.url(DummyDefinition, :private, {Arc.File.new(@img), nil})


### PR DESCRIPTION
@stavro Hi! First of all thanks a lot for your work on this library - it has been very useful and is crucial for Elixir/Phoenix projects moving forward. 

I ran into an issue where the AWS user for my application was unauthorized to upload to S3, but every time that I attempted an upload using Arc I would get `{:ok, "filename.jpg}`. I checked uploading directly with ExAws and it returned the appropriate error, so I figured we should expose these in Arc as well. I modified the API to continue returning `{:ok, "filename"}` on success, but now it will return a two item error tuple if ExAws returns an error tuple. This tuple is in a similar shape to the success tuple for simplicity's sake: 
```
{:error, [{:http_error, 403, "some xml"}, {:http_error, 404, "other xml"}]}
```

Let me know what you think, and if you would like me to make any changes to get this into master. 
P.S. I also needed to add Poison directly into my deps to get all the tests to pass on master.

Thanks,
Doug