### PR TITLE
Storage Type From Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,20 +148,12 @@ config :arc,
 Arc currently supports Amazon S3 and local destinations for file uploads.
 
 ### Local Configuration
+
+Change configuration to use `Arc.Storage.Local`.
+
 ```elixir
-defmodule Avatar do
-  use Arc.Definition
-
-  @versions [:original, :thumb]
-
-  def transform(:thumb, _) do
-    {:convert, "-strip -thumbnail 100x100^ -gravity center -extent 100x100 -format png"}
-  end
-
-   def __storage, do: Arc.Storage.Local
-
-   def filename(version,  file), do: "#{version}-#{file.file_name}"
-end
+config :arc,
+  storage: Arc.Storage.Local
 ```
 
 ### S3 Configuration

--- a/lib/arc/definition/storage.ex
+++ b/lib/arc/definition/storage.ex
@@ -8,7 +8,7 @@ defmodule Arc.Definition.Storage do
       def validate(_), do: true
       def default_url(version, _), do: default_url(version)
       def default_url(_), do: nil
-      def __storage, do: Arc.Storage.S3
+      def __storage, do: Application.get_env(:arc, :storage) || Arc.Storage.S3
 
       defoverridable [storage_dir: 2, filename: 2, validate: 1, default_url: 1, default_url: 2, __storage: 0]
 

--- a/test/storage/local_test.exs
+++ b/test/storage/local_test.exs
@@ -4,9 +4,11 @@ defmodule ArcTest.Storage.Local do
 
   setup_all do
     File.mkdir_p("arctest/uploads")
+    Application.put_env :arc, :storage, Arc.Storage.Local
 
     on_exit fn ->
       File.rm_rf("arctest/uploads")
+      Application.put_env :arc, :storage, Arc.Storage.S3
     end
   end
 
@@ -19,7 +21,6 @@ defmodule ArcTest.Storage.Local do
     def transform(:original, _), do: {:noaction}
     def __versions, do: [:original, :thumb]
     def storage_dir(_, _), do: "arctest/uploads"
-    def __storage, do: Arc.Storage.Local
     def filename(:original, {file, _}), do: "original-#{Path.basename(file.file_name, Path.extname(file.file_name))}"
     def filename(:thumb, {file, _}), do: "1/thumb-#{Path.basename(file.file_name, Path.extname(file.file_name))}"
   end


### PR DESCRIPTION
Source issue #32.

Changes:
- Storage method specific in config, rather than implementation definition (defaults to `Arc.Storage.S3`). This allows the user to change the storage type for testing.

Let me know if you think this is a worthwhile change, or if you want to see more tests.