### PR TITLE
added s3 metadata options (content-type, cache-control, etc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,14 +217,14 @@ def acl(:thumb, _), do: :public_read
 
 Supported access control lists for Amazon S3 are:
 
-|ACL|Permissions Added to ACL|
-|---|---|
-|`:private`|Owner gets `FULL_CONTROL`. No one else has access rights (default).|
-|`:public_read`|Owner gets `FULL_CONTROL`. The `AllUsers` group gets READ access.|
-|`:public_read_write`|Owner gets `FULL_CONTROL`. The `AllUsers` group gets `READ` and `WRITE` access. Granting this on a bucket is generally not recommended.|
-|`:authenticated_read`|Owner gets `FULL_CONTROL`. The `AuthenticatedUsers` group gets `READ` access.|
-|`:bucket_owner_read`|Object owner gets `FULL_CONTROL`. Bucket owner gets `READ` access.|
-|`:bucket_owner_full_control`|Both the object owner and the bucket owner get `FULL_CONTROL` over the object.|
+| ACL                          | Permissions Added to ACL                                                                                                                |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `:private`                   | Owner gets `FULL_CONTROL`. No one else has access rights (default).                                                                     |
+| `:public_read`               | Owner gets `FULL_CONTROL`. The `AllUsers` group gets READ access.                                                                       |
+| `:public_read_write`         | Owner gets `FULL_CONTROL`. The `AllUsers` group gets `READ` and `WRITE` access. Granting this on a bucket is generally not recommended. |
+| `:authenticated_read`        | Owner gets `FULL_CONTROL`. The `AuthenticatedUsers` group gets `READ` access.                                                           |
+| `:bucket_owner_read`         | Object owner gets `FULL_CONTROL`. Bucket owner gets `READ` access.                                                                      |
+| `:bucket_owner_full_control` | Both the object owner and the bucket owner get `FULL_CONTROL` over the object.                                                          |
 
 For more information on the behavior of each of these, please consult Amazon's documentation for [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
 
@@ -402,7 +402,6 @@ Avatar.url({"selfie.png", current_user}, :thumb) #=> "https://s3.amazonaws.com/b
 Contributions are welcome.  Here is my current roadmap:
 
   * Object deletion
-  * Cache-control headers
   * Ease migration for version (or acl) changes
   * Alternative storage destinations (eg, Filesystem)
   * Solidify public API

--- a/lib/arc/definition/storage.ex
+++ b/lib/arc/definition/storage.ex
@@ -8,9 +8,18 @@ defmodule Arc.Definition.Storage do
       def validate(_), do: true
       def default_url(version, _), do: default_url(version)
       def default_url(_), do: nil
+      def options(_, _), do: %{content_disposition: nil,
+                               content_encoding: nil,
+                               content_length: nil,
+                               content_type: nil,
+                               expect: nil,
+                               storage_class: "STANDARD",
+                               website_redirect_location: nil,
+                               encryption: nil,
+                               meta: nil}
       def __storage, do: Arc.Storage.S3
 
-      defoverridable [storage_dir: 2, filename: 2, validate: 1, default_url: 1, default_url: 2, __storage: 0]
+      defoverridable [storage_dir: 2, filename: 2, options: 2, validate: 1, default_url: 1, default_url: 2, __storage: 0]
 
       @before_compile Arc.Definition.Storage
     end

--- a/lib/arc/storage/s3.ex
+++ b/lib/arc/storage/s3.ex
@@ -6,7 +6,15 @@ defmodule Arc.Storage.S3 do
     s3_key = Path.join(destination_dir, file.file_name)
     binary = File.read!(file.path)
     acl = definition.acl(version, {file, scope})
-    ExAws.S3.put_object(bucket, s3_key, binary, [acl: acl])
+
+    options = definition.options(version, {file, scope})
+              |> Map.to_list
+              |> Enum.filter fn(e) -> elem(e, 1) != nil end
+
+    # Stuff that's not metadata
+    options = [acl: acl] ++ options
+
+    ExAws.S3.put_object(bucket, s3_key, binary, options)
     file.file_name
   end
 

--- a/lib/mix/tasks/g.ex
+++ b/lib/mix/tasks/g.ex
@@ -65,6 +65,20 @@ defmodule Mix.Tasks.Arc do
       # def default_url(version, scope) do
       #   "/images/avatars/default_\#{version}.png"
       # end
+
+      # Fine tune how your file is stored
+      # Elements with value nil will get ignored
+      # def options(version, {file, scope}) do
+      #   %{content_disposition: nil,
+      #     content_encoding: nil,
+      #     content_length: nil,
+      #     content_type: nil,
+      #     expect: nil,
+      #     storage_class: "STANDARD", # maybe REDUCED_REDUNDANCY?
+      #     website_redirect_location: nil,
+      #     encryption: nil,
+      #     meta: nil} # [{"Your-Key", "Your-Value"}]
+      # end
     end
     """
 


### PR DESCRIPTION
This PR adds all options ex_aws currently has when uploading things to s3. 

I tried to do it as similar as possible like the other things. Likely needs to get changed slightly once https://github.com/stavro/arc/pull/39 got merged