### PR TITLE
Return tuple from Arc.Storage.Local#put

### DIFF
--- a/lib/arc/storage/local.ex
+++ b/lib/arc/storage/local.ex
@@ -4,7 +4,7 @@ defmodule Arc.Storage.Local do
     path = Path.join(destination_dir, file.file_name)
     path |> Path.dirname() |> File.mkdir_p()
     File.copy!(file.path, path)
-    file.file_name
+    {:ok, file.file_name}
   end
 
   def url(definition, version, file_and_scope, options \\ []) do


### PR DESCRIPTION
The `handle_responses` method in arc/actions/store.ex expects a list of tuples, but Storage.Local was returning a string.