### PR TITLE
Allow transform via arbitrary commands

### DIFF
--- a/lib/arc/definition/versioning.ex
+++ b/lib/arc/definition/versioning.ex
@@ -11,12 +11,8 @@ defmodule Arc.Definition.Versioning do
     conversion = definition.transform(version, {file, scope})
 
     case conversion do
-      {:noaction} -> "#{name}#{Path.extname(file.file_name)}"
-      {:convert, args} ->
-        extension = case Regex.run(~r/-format[ ]*(\w*)/, args) do
-          nil -> "#{name}#{Path.extname(file.file_name)}"
-          [_, ext] -> "#{name}.#{ext}"
-        end
+      {_, _, ext} -> "#{name}.#{ext}"
+       _          -> "#{name}#{Path.extname(file.file_name)}"
     end
   end
 

--- a/lib/arc/processor.ex
+++ b/lib/arc/processor.ex
@@ -7,7 +7,11 @@ defmodule Arc.Processor do
     file
   end
 
-  defp apply_transformation(file, {:convert, conversion}) do
-    Arc.Transformations.Convert.apply(file, conversion)
+  defp apply_transformation(file, {cmd, conversion, _}) do
+    apply_transformation(file,{cmd, conversion})
+  end
+
+  defp apply_transformation(file, {cmd, conversion}) do
+    Arc.Transformations.Convert.apply(cmd, file, conversion)
   end
 end

--- a/lib/arc/transformations/convert.ex
+++ b/lib/arc/transformations/convert.ex
@@ -1,10 +1,10 @@
 defmodule Arc.Transformations.Convert do
-  def apply(file, args) do
-    new_path = temp_path
+  def apply(cmd, file, args) do
+    new_path     = temp_path
+    esc_new_path = String.replace(new_path, " ", "\\ ")
+    args         = if is_function(args), do: args.(file.path, esc_new_path),  else: "#{file.path} #{args} #{esc_new_path}"
 
-    System.cmd("convert",
-      ~w(#{file.path} #{args} #{String.replace(new_path, " ", "\\ ")}),
-      stderr_to_stdout: true)
+    System.cmd(to_string(cmd), ~w(#{args}), stderr_to_stdout: true)
     |> handle_exit_code
 
     %Arc.File{file | path: new_path}

--- a/test/processor_test.exs
+++ b/test/processor_test.exs
@@ -9,6 +9,7 @@ defmodule ArcTest.Processor do
     def validate({file, _}), do: String.ends_with?(file.file_name, ".png")
     def transform(:original, _), do: {:noaction}
     def transform(:thumb, _), do: {:convert, "-strip -thumbnail 10x10"}
+    def transform(:med, _), do: {:convert, fn(in_path, out_path) -> "#{in_path} -strip -thumbnail 10x10 #{out_path}" end, :jpg}
     def __versions, do: [:original, :thumb]
   end
 
@@ -28,6 +29,14 @@ defmodule ArcTest.Processor do
 
   test "transforms a copied version of file according to the specified transformation" do
     new_file = Arc.Processor.process(DummyDefinition, :thumb, {Arc.File.new(@img), nil})
+    assert new_file.path != @img
+    assert "128x128" == geometry(@img) #original file untouched
+    assert "10x10" == geometry(new_file.path)
+    cleanup(new_file.path)
+  end
+
+  test "transforms a copied version of file according to the specified function transformation" do
+    new_file = Arc.Processor.process(DummyDefinition, :med, {Arc.File.new(@img), nil})
     assert new_file.path != @img
     assert "128x128" == geometry(@img) #original file untouched
     assert "10x10" == geometry(new_file.path)


### PR DESCRIPTION
This PR adds three things

- Allows using an arbitrary binary for transforms
```elixir
{:convert, "..."}
{:ffmpeg, "..."}
```
- Allows passing a function in the transform tuple to get direct access to the argument string. It's currently not possible to perform some more advanced transformations, for example pulling a single frame from a gif as you need to specify the frame via filename.gif[1] and there's a space between the in-file and args.
```elixir
{:convert, fn(in_path, out_path) -> "#{ext}:#{in_path}[1] -strip -thumbnail x255> jpg:#{out_path}" end}
```
- The third argument in the transform tuple explicitly sets the output file ext. Since its possible to use arbitrary binaries, they don't all use or understand in the same way the `-format ext` syntax.
```elixir
{:ffmpeg, "...", :jpg}
```