### PR TITLE
Only convert transformation arguments to list if it isn't one

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ To transform an image, the definition module must define a `transform/2` functio
 This transform handler accepts the version atom, as well as the file/scope argument, and is responsible for returning one of the following:
   * `:noaction` - The original file will be stored as-is.
   * `{executable, args}` - The `executable` will be called with `System.cmd` with the format `#{original_file_path} #{args} #{transformed_file_path}`.
-  * `{executable, fn(input, output) -> args end}` - If your executable expects arguments in a format other than the above, you may supply a function to the conversion tuple which will be invoked to generate the arguments.
+  * `{executable, fn(input, output) -> args end}` - If your executable expects arguments in a format other than the above, you may supply a function to the conversion tuple which will be invoked to generate the arguments. The arguments can be returned as a string (e.g. – `" #{input} -strip -thumbnail 10x10 #{output}"`) or a list (e.g. – `[input, "-strip", "-thumbnail", "10x10", output]`) for even more control.
   * `{executable, args, output_extension}` - If your transformation changes the file extension (eg, converting to `png`), then the new file extension must be explicit.
 
 ### ImageMagick transformations

--- a/lib/arc/transformations/convert.ex
+++ b/lib/arc/transformations/convert.ex
@@ -6,11 +6,14 @@ defmodule Arc.Transformations.Convert do
 
     ensure_executable_exists!(program)
 
-    System.cmd(program, ~w(#{args}), stderr_to_stdout: true)
+    System.cmd(program, args_list(args), stderr_to_stdout: true)
       |> handle_exit_code!
 
     %Arc.File{file | path: new_path}
   end
+
+  defp args_list(args) when is_list(args), do: args
+  defp args_list(args), do: ~w(#{args})
 
   defp ensure_executable_exists!(program) do
     unless System.find_executable(program) do

--- a/test/processor_test.exs
+++ b/test/processor_test.exs
@@ -10,6 +10,7 @@ defmodule ArcTest.Processor do
     def transform(:original, _), do: :noaction
     def transform(:thumb, _), do: {:convert, "-strip -thumbnail 10x10"}
     def transform(:med, _), do: {:convert, fn(input, output) -> " #{input} -strip -thumbnail 10x10 #{output}" end, :jpg}
+    def transform(:small, _), do: {:convert, fn(input, output) -> [input, "-strip", "-thumbnail", "10x10", output] end, :jpg}
     def __versions, do: [:original, :thumb]
   end
 
@@ -41,8 +42,16 @@ defmodule ArcTest.Processor do
     cleanup(new_file.path)
   end
 
-  test "transforms a copied version of file according to the specified function transformation" do
+  test "transforms a copied version of file according to a function transformation that returns a string" do
     new_file = Arc.Processor.process(DummyDefinition, :med, {Arc.File.new(@img), nil})
+    assert new_file.path != @img
+    assert "128x128" == geometry(@img) #original file untouched
+    assert "10x10" == geometry(new_file.path)
+    cleanup(new_file.path)
+  end
+
+  test "transforms a copied version of file according to a function transformation that returns a list" do
+    new_file = Arc.Processor.process(DummyDefinition, :small, {Arc.File.new(@img), nil})
     assert new_file.path != @img
     assert "128x128" == geometry(@img) #original file untouched
     assert "10x10" == geometry(new_file.path)


### PR DESCRIPTION
I also made mention in the readme, but kept it as a separate commit so you can cherry pick if you don't like how I worded it.

(See https://github.com/stavro/arc/issues/63 for more context.)