### PR TITLE
Add config option for Arc.Storage.Local directory

### DIFF
--- a/lib/arc/storage/local.ex
+++ b/lib/arc/storage/local.ex
@@ -1,7 +1,7 @@
 defmodule Arc.Storage.Local do
   def put(definition, version, {file, scope}) do
     destination_dir = definition.storage_dir(version, {file, scope})
-    path = Path.join(destination_dir, file.file_name)
+    path = Path.join([local_dir, destination_dir, file.file_name])
     path |> Path.dirname() |> File.mkdir_p()
     File.copy!(file.path, path)
     {:ok, file.file_name}
@@ -18,8 +18,13 @@ defmodule Arc.Storage.Local do
 
   defp build_local_path(definition, version, file_and_scope) do
     Path.join([
+      local_dir,
       definition.storage_dir(version, file_and_scope),
       Arc.Definition.Versioning.resolve_file_name(definition, version, file_and_scope)
     ])
+  end
+
+  defp local_dir do
+    Application.get_env(:arc, :local_dir) || ""
   end
 end

--- a/test/storage/local_test.exs
+++ b/test/storage/local_test.exs
@@ -38,4 +38,22 @@ defmodule ArcTest.Storage.Local do
     refute File.exists?("arctest/uploads/original-image.png")
     refute File.exists?("arctest/uploads/1/thumb-image.png")
   end
+
+  test "local_dir option" do
+    local_dir = "arctest/uploads/local_dir"
+    Application.put_env :arc, :local_dir, local_dir
+
+    assert {:ok, "original-image.png"} == Arc.Storage.Local.put(DummyDefinition, :original, {Arc.File.new(%{filename: "original-image.png", path: @img}), nil})
+    assert {:ok, "1/thumb-image.png"} == Arc.Storage.Local.put(DummyDefinition, :thumb, {Arc.File.new(%{filename: "1/thumb-image.png", path: @img}), nil})
+
+    assert File.exists?("#{local_dir}/arctest/uploads/original-image.png")
+    assert File.exists?("#{local_dir}/arctest/uploads/1/thumb-image.png")
+    assert "#{local_dir}/arctest/uploads/original-image.png" == DummyDefinition.url("image.png", :original)
+    assert "#{local_dir}/arctest/uploads/1/thumb-image.png" == DummyDefinition.url("1/image.png", :thumb)
+
+    Arc.Storage.Local.delete(DummyDefinition, :original, {%{file_name: "image.png"}, nil})
+    Arc.Storage.Local.delete(DummyDefinition, :thumb, {%{file_name: "image.png"}, nil})
+    refute File.exists?("#{local_dir}/arctest/uploads/original-image.png")
+    refute File.exists?("#{local_dir}/arctest/uploads/1/thumb-image.png")
+  end
 end


### PR DESCRIPTION
This PR introduces a `local_dir` config option that allows one to specify a prefix for the `Arc.Storage.Local` location. This is especially useful for running tests.

Example usage:

```elixir
# config/test.exs
config :arc, local_dir: "test/uploads"

defmodule MyApp.Avatar.Uploader do
  use Arc.Definition
  use Arc.Ecto.Definition

  def __storage, do: Arc.Storage.Local

  def storage_dir(_version, {_file, _scope}) do
    "avatars"
  end
end

MyApp.Avatar.Uploader.store(%Plug.Upload{filename: "file.png", path: "/a/b/c"})
# File will be stored in "test/uploads/avatars"
```