### PR TITLE
Fixed test skipping.

### DIFF
--- a/test/storage/s3_test.exs
+++ b/test/storage/s3_test.exs
@@ -100,6 +100,8 @@ defmodule ArcTest.Storage.S3 do
     Application.put_env :ex_aws, :secret_access_key,  System.get_env("ARC_TEST_S3_SECRET")
   end
 
+  @tag :s3
+  @tag timeout: 15000
   test "virtual_host" do
     Application.put_env :arc, :virtual_host, true
     assert "https://#{env_bucket}.s3.amazonaws.com/arctest/uploads/image.png" == DummyDefinition.url(@img)


### PR DESCRIPTION
If no `$ARC_TEST_BUCKET` is set this test fails. It is now skipped.
The output was:

> .............
> 
>   1) test virtual_host (ArcTest.Storage.S3)
>      test/storage/s3_test.exs:103
>      Assertion with == failed
>      code: "https://s3.amazonaws.com/#{env_bucket}/arctest/uploads/image.png" == DummyDefinition.url(@img)
>      lhs:  "https://s3.amazonaws.com//arctest/uploads/image.png"
>      rhs:  "https://s3.amazonaws.com/arctest/uploads/image.png"
>      stacktrace:
>        test/storage/s3_test.exs:108
> 
> ........
> Finished in 1.0 seconds (0.4s on load, 0.5s on tests)
> 29 tests, 1 failure, 7 skipped

Right now:

> Excluding tags: [:s3]
> 
> .....................
> Finished in 0.9 seconds (0.4s on load, 0.5s on tests)
> 29 tests, 0 failures, 8 skipped

I hope I did it correctly.