### PR TITLE
Custom error keys returned from validate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,16 +284,20 @@ end
 
 While storing files on S3 (rather than your harddrive) eliminates some malicious attack vectors, it is strongly encouraged to validate the extensions of uploaded files as well.
 
-Arc delegates validation to a `validate/1` function with a tuple of the file and scope.  As an example, to validate that an uploaded file conforms to popular image formats, you may use:
+Arc delegates validation to a `validate/1` function with a tuple of the file and scope. The function needs to return a tuple of two atoms `{:ok, :valid}` or `{:error, :reason}`. As an example, to validate that an uploaded file conforms to popular image formats, you may use:
 
 ```elixir
 defmodule Avatar do
   use Arc.Definition
   @extension_whitelist ~w(.jpg .jpeg .gif .png)
 
-  def validate({file, _}) do   
+  def validate({file, _}) do
     file_extension = file.file_name |> Path.extname |> String.downcase
-    Enum.member?(@extension_whitelist, file_extension)
+    if Enum.member?(@extension_whitelist, file_extension) do
+      {:ok, :valid_extension}
+    else
+      {:error, :invalid_extension}
+    end
   end
 end
 ```
@@ -431,7 +435,7 @@ defmodule Avatar do
 
   def acl(:thumb, _), do: :public_read
 
-  def validate({file, _}) do   
+  def validate({file, _}) do
     file_extension = file.file_name |> Path.extname |> String.downcase
     Enum.member?(@extension_whitelist, file_extension)
   end

--- a/lib/arc/actions/store.ex
+++ b/lib/arc/actions/store.ex
@@ -23,8 +23,8 @@ defmodule Arc.Actions.Store do
 
   defp put(definition, {%Arc.File{}=file, scope}) do
     case definition.validate({file, scope}) do
-      true -> put_versions(definition, {file, scope})
-      _    -> {:error, :invalid_file}
+      {:ok, _} -> put_versions(definition, {file, scope})
+      {:error, error}    -> {:error, error}
     end
   end
 

--- a/lib/arc/actions/store.ex
+++ b/lib/arc/actions/store.ex
@@ -24,7 +24,8 @@ defmodule Arc.Actions.Store do
   defp put(definition, {%Arc.File{}=file, scope}) do
     case definition.validate({file, scope}) do
       {:ok, _} -> put_versions(definition, {file, scope})
-      {:error, error}    -> {:error, error}
+      {_, error}    -> {:error, error}
+      _ -> {:error, :invalid_file}
     end
   end
 

--- a/lib/arc/definition/storage.ex
+++ b/lib/arc/definition/storage.ex
@@ -5,7 +5,7 @@ defmodule Arc.Definition.Storage do
 
       def filename(_, {file, _}), do: Path.basename(file.file_name, Path.extname(file.file_name))
       def storage_dir(_, _), do: "uploads"
-      def validate(_), do: true
+      def validate(_), do: {:ok, :valid}
       def default_url(version, _), do: default_url(version)
       def default_url(_), do: nil
       def __storage, do: Arc.Storage.S3

--- a/test/actions/store_test.exs
+++ b/test/actions/store_test.exs
@@ -7,7 +7,13 @@ defmodule ArcTest.Actions.Store do
     use Arc.Actions.Store
     use Arc.Definition.Storage
 
-    def validate({file, _}), do: String.ends_with?(file.file_name, ".png")
+    def validate({file, _}) do
+      case String.ends_with?(file.file_name, ".png") do
+        true -> {:ok, :ok}
+        false -> {:error, :invalid_file}
+      end
+    end
+
     def transform(_, _), do: :noaction
     def __versions, do: [:original, :thumb]
   end


### PR DESCRIPTION
Hi Sean,
I have a specific case: I'd like to user `arc` and `arc_ecto` to validate if extension and MIME type of uploaded file are allowed in the current schema and show the reason of invalidity to the user. I changes `validate` function. Now it enforces Tuple as the return type `{:ok, :valid}` or `{:error, :reason}`.

Unfortunately, it won't work for me because of [Ecto cast function](https://hexdocs.pm/ecto/Ecto.Type.html#cast/2) which return type is either a Tuple `{:ok, casted_valie}` or an Atom `:error`.

I'm creating pull request because the code works and some people may find it useful. Feel free to either accept or reject it.

For now only and probably the best way of solving my problem is to run the validations twice. Once in `validate` function and once after parameters have been cast to their corresponding Ecto types.

I'll gladly accept any advice regarding this case.

Best,
Dawid