### PR TITLE
Add ability to set S3 bucket from runtime env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,13 @@ config :arc,
   bucket: "uploads"
 ```
 
+You may also set the bucket from an environment variable:
+
+```elixir
+config :arc,
+  bucket: {:system, "S3_BUCKET"}
+```
+
 In addition, ExAws must be configured with the appropriate Amazon S3 credentials.
 
 ExAws has by default the following configuration (which you may override if you wish):

--- a/lib/arc/storage/s3.ex
+++ b/lib/arc/storage/s3.ex
@@ -67,6 +67,10 @@ defmodule Arc.Storage.S3 do
 
   defp bucket do
     {:ok, bucket_name} = Application.fetch_env(:arc, :bucket)
-    bucket_name
+
+    case bucket_name do
+      {:system, env_var} when is_binary(env_var) -> System.get_env(env_var)
+      name -> name
+    end
   end
 end

--- a/test/storage/s3_test.exs
+++ b/test/storage/s3_test.exs
@@ -94,7 +94,7 @@ defmodule ArcTest.Storage.S3 do
     Application.ensure_all_started(:httpoison)
     Application.ensure_all_started(:ex_aws)
     Application.put_env :arc, :virtual_host, false
-    Application.put_env :arc, :bucket, env_bucket
+    Application.put_env :arc, :bucket, { :system, "ARC_TEST_BUCKET" }
     # Application.put_env :ex_aws, :s3, [scheme: "https://", host: "s3.amazonaws.com", region: "us-west-2"]
     Application.put_env :ex_aws, :access_key_id, System.get_env("ARC_TEST_S3_KEY")
     Application.put_env :ex_aws, :secret_access_key,  System.get_env("ARC_TEST_S3_SECRET")


### PR DESCRIPTION
Like we do with `access_key_id`, it's useful to be able to set `bucket_name` from a runtime environment var (since config is often created at compile time). This patch adds that ability.