### PR TITLE
Add env settings to include extension in temp path generation

### DIFF
--- a/lib/arc/transformations/convert.ex
+++ b/lib/arc/transformations/convert.ex
@@ -1,6 +1,6 @@
 defmodule Arc.Transformations.Convert do
   def apply(cmd, file, args) do
-    new_path = temp_path()
+    new_path = temp_path(file)
     args     = if is_function(args), do: args.(file.path, new_path), else: "#{file.path} #{args} #{new_path}"
     program  = to_string(cmd)
 
@@ -26,8 +26,20 @@ defmodule Arc.Transformations.Convert do
     raise Arc.ConvertError, message: error_message, exit_code: exit_code
   end
 
-  defp temp_path() do
+  defp temp_path(file) do
     rand = Base.encode32(:crypto.rand_bytes(20))
-    Path.join(System.tmp_dir, rand)
+    Path.join(System.tmp_dir, rand) <> add_file_extension(file)
+  end
+
+  def add_file_extension(file) do
+    if include_extension_temp_path do
+      Path.extname(file.path)
+    else
+      ""
+    end
+  end
+
+  defp include_extension_temp_path do
+    Application.get_env(:arc, :include_extension_temp_path) || false
   end
 end


### PR DESCRIPTION
The image processing library `vips` needs the output file parameter to have an
extension. This adds an option to include the file extension in the generated temp
path for the transformation.

Instead of generating `/var/folders/43/7b0x8l` it will generate `/var/folders/43/7b0x8l.jpg`.

Now my uploaders can finally use the awesome and fast `vipsthumbnail` command like this:

```elixir
{:vipsthumbnail, fn(source, destination) ->
  "#{source} --size 200x200 --crop --rotate -o #{destination}[Q=100,optimize_coding,strip]"
end}
```