### PR TITLE
Return tuple instead of raising on convert failure

### DIFF
--- a/lib/arc/transformations/convert.ex
+++ b/lib/arc/transformations/convert.ex
@@ -6,10 +6,12 @@ defmodule Arc.Transformations.Convert do
 
     ensure_executable_exists!(program)
 
-    System.cmd(program, args_list(args), stderr_to_stdout: true)
-      |> handle_exit_code!
-
-    %Arc.File{file | path: new_path}
+    case System.cmd(program, args_list(args), stderr_to_stdout: true) do
+      {_, 0} ->
+        %Arc.File{file | path: new_path}
+      {error_message, _exit_code} ->
+        {:error, error_message}
+    end
   end
 
   defp args_list(args) when is_list(args), do: args
@@ -19,11 +21,6 @@ defmodule Arc.Transformations.Convert do
     unless System.find_executable(program) do
       raise Arc.MissingExecutableError, message: program
     end
-  end
-
-  defp handle_exit_code!({_, 0}), do: :ok
-  defp handle_exit_code!({error_message, exit_code}) do
-    raise Arc.ConvertError, message: error_message, exit_code: exit_code
   end
 
   defp temp_path() do

--- a/test/processor_test.exs
+++ b/test/processor_test.exs
@@ -58,10 +58,8 @@ defmodule ArcTest.Processor do
     cleanup(new_file.path)
   end
 
-  test "raises an error in an invalid transformation" do
-    assert_raise Arc.ConvertError, ~r"unrecognized option", fn ->
-      Arc.Processor.process(BrokenDefinition, :thumb, {Arc.File.new(@img), nil})
-    end
+  test "returns tuple in an invalid transformation" do
+    assert {:error, _} = Arc.Processor.process(BrokenDefinition, :thumb, {Arc.File.new(@img), nil})
   end
 
   test "raises an error if the given transformation executable cannot be found" do


### PR DESCRIPTION
Elixir documentation[1] describes how returning tuples allow developers
to control flow according to successful or failed paths using pattern
matching.

Elixir methods offer a "bang" version if developers would rather have
the application fail and exit, or use `try`/`catch`.

In our case we use scripts to convert documents from PDF to PNG or HTML and text according to LibreOffice and ImageMagick capabilities with each document in question.

We could also add a bang version of `store` and the call chain to keep the current exit behavior if you think it's necessary.

[1] http://elixir-lang.org/getting-started/try-catch-and-rescue.html