### PR TITLE
Add encryption as possible object header

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ The definition module may specify custom headers to pass through to S3 during ob
   *  :expires
   *  :storage_class
   *  :website_redirect_location
+  *  :encryption (set to "AES256" for encryption at rest)
+
 
 As an example, to explicitly specify the content-type of an object, you may define a `s3_object_headers/2` function in your definition, which returns a Keyword list, or Map of desired headers.
 


### PR DESCRIPTION
This option is provided by ex_aws, and works by default in Arc