### PR TITLE
Drop unused statement

### DIFF
--- a/lib/arc/actions/store.ex
+++ b/lib/arc/actions/store.ex
@@ -53,7 +53,7 @@ defmodule Arc.Actions.Store do
   defp put_version(definition, version, {file, scope}) do
     case Arc.Processor.process(definition, version, {file, scope}) do
       {:error, error} -> {:error, error}
-      {:ok, file} -> file
+      {:ok, file} ->
         file_name = Arc.Definition.Versioning.resolve_file_name(definition, version, {file, scope})
         file      = %Arc.File{file | file_name: file_name}
         definition.__storage.put(definition, version, {file, scope})


### PR DESCRIPTION
Fixes warning:

> variable file in code block has no effect as it is never returned
> (remove the variable or assign it to _ to avoid warnings)
