### PR TITLE
add starter slash for urls in local storage

### DIFF
--- a/lib/arc/storage/local.ex
+++ b/lib/arc/storage/local.ex
@@ -8,7 +8,7 @@ defmodule Arc.Storage.Local do
   end
 
   def url(definition, version, file_and_scope, _options \\ []) do
-    build_local_path(definition, version, file_and_scope)
+    "/" <> build_local_path(definition, version, file_and_scope)
   end
 
   def delete(definition, version, file_and_scope) do


### PR DESCRIPTION
url/2 was returning a non '/' prefixed url, breaking any page but the root route.