### PR TITLE
Add store/3 to apply a reducing function on results

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,22 @@ Avatar.store({%Plug.Upload{}, scope}) #=> {:ok, "file.png"}
 
 This scope will be available throughout the definition module to be used as an input to the storage parameters (eg, store files in `/uploads/#{scope.id}`).
 
+## Advanced
+
+Access the information of each processed version with a reducer function.
+
+```elixir
+# Example to calculate total size of stored files
+Avatar.store("/path/to/my-file.png", 0, fn(
+  {:ok, _result, _version, file}, acc) ->
+    stat = File.stat!(file.path)
+    acc + stat.size
+  {:err, _errmsg, _version, _file} ->
+    acc
+end)
+#=> {:ok, "my-file.png", 12345}
+```
+
 ## Transformations
 
 Arc can be used to facilitate transformations of uploaded files via any system executable.  Some common operations you may want to take on uploaded files include resizing an uploaded avatar with ImageMagick or extracting a still image from a video with FFmpeg.
@@ -352,7 +368,7 @@ defmodule Avatar do
   use Arc.Definition
   @extension_whitelist ~w(.jpg .jpeg .gif .png)
 
-  def validate({file, _}) do   
+  def validate({file, _}) do
     file_extension = file.file_name |> Path.extname() |> String.downcase()
     Enum.member?(@extension_whitelist, file_extension)
   end
@@ -495,7 +511,7 @@ defmodule Avatar do
 
   def acl(:thumb, _), do: :public_read
 
-  def validate({file, _}) do   
+  def validate({file, _}) do
     file_extension = file.file_name |> Path.extname |> String.downcase
     Enum.member?(@extension_whitelist, file_extension)
   end

--- a/lib/arc/actions/store.ex
+++ b/lib/arc/actions/store.ex
@@ -1,43 +1,48 @@
 defmodule Arc.Actions.Store do
   defmacro __using__(_) do
     quote do
-      def store(args), do: Arc.Actions.Store.store(__MODULE__, args)
+      def store(args, initial \\ nil, reducer \\ &(&1)), do: Arc.Actions.Store.store(__MODULE__, args, initial, reducer)
     end
   end
 
-  def store(definition, {file, scope}) when is_binary(file) or is_map(file) do
-    put(definition, {Arc.File.new(file), scope})
+  def store(definition, {file, scope}, initial, reducer) when is_binary(file) or is_map(file) do
+    put(definition, {Arc.File.new(file), scope}, initial, reducer)
   end
 
-  def store(definition, filepath) when is_binary(filepath) or is_map(filepath) do
-    store(definition, {filepath, nil})
+  def store(definition, filepath, initial, reducer) when is_binary(filepath) or is_map(filepath) do
+    store(definition, {filepath, nil}, initial, reducer)
   end
 
   #
   # Private
   #
 
-  defp put(_definition, {{:error, _msg}, _scope}) do
+  defp put(_definition, {{:error, _msg}, _scope}, _initial, _reducer) do
     {:error, :invalid_file}
   end
 
-  defp put(definition, {%Arc.File{}=file, scope}) do
+  defp put(definition, {%Arc.File{}=file, scope}, initial, reducer) do
     case definition.validate({file, scope}) do
-      true -> put_versions(definition, {file, scope})
+      true -> put_versions(definition, {file, scope}, initial, reducer)
       _    -> {:error, :invalid_file}
     end
   end
 
-  defp put_versions(definition, {file, scope}) do
+  defp put_versions(definition, {file, scope}, initial, reducer) do
     definition.__versions
     |> Enum.map(fn(r)    -> async_put_version(definition, r, {file, scope}) end)
     |> Enum.map(fn(task) -> Task.await(task, version_timeout) end)
-    |> handle_responses(file.file_name)
+    |> handle_responses(file.file_name, initial, reducer)
   end
 
-  defp handle_responses(responses, filename) do
+  defp handle_responses(responses, filename, nil, _reducer) do
     errors = Enum.filter(responses, fn(resp) -> elem(resp, 0) == :error end) |> Enum.map(fn(err) -> elem(err, 1) end)
     if Enum.empty?(errors), do: {:ok, filename}, else: {:error, errors}
+  end
+  defp handle_responses(responses, filename, initial, reducer) do
+    result = handle_responses(responses, filename, nil, nil)
+    reduce_result = Enum.reduce(responses, initial, reducer)
+    Tuple.append(result, reduce_result)
   end
 
   defp version_timeout do
@@ -56,7 +61,10 @@ defmodule Arc.Actions.Store do
       {:ok, file} ->
         file_name = Arc.Definition.Versioning.resolve_file_name(definition, version, {file, scope})
         file      = %Arc.File{file | file_name: file_name}
-        definition.__storage.put(definition, version, {file, scope})
+        case definition.__storage.put(definition, version, {file, scope}) do
+          {:ok, response}   -> {:ok, response, version, file}
+          {:error, err_msg} -> {:error, err_msg, version, file}
+        end
     end
   end
 end

--- a/test/actions/store_test.exs
+++ b/test/actions/store_test.exs
@@ -61,4 +61,12 @@ defmodule ArcTest.Actions.Store do
 
     Application.put_env :arc, :version_timeout, 15_000
   end
+
+  test "capture data during store" do
+    with_mock Arc.Storage.S3, [put: fn(DummyDefinition, _, {%{file_name: "image.png", path: @img}, :scope}) -> {:ok, "resp"} end] do
+      assert DummyDefinition.store({%{filename: "image.png", path: @img}, :scope}, [], fn({_okerr, _result, version, _file}, acc) ->
+        [version | acc]
+      end) == {:ok, "image.png", [:thumb, :original]}
+    end
+  end
 end


### PR DESCRIPTION
This adds `store/3` which allows a reducer function to be called against each version.
I use this to calculate the total of the storage used (example in the README).

``` elixir
{:ok, filename} = Definition.store(data)
{:ok, filename, result} = Definition.store(data, initial, reducer)
```
