### PR TITLE
pass options through build_presigned_url

### DIFF
--- a/lib/arc/storage/s3.ex
+++ b/lib/arc/storage/s3.ex
@@ -69,9 +69,10 @@ defmodule Arc.Storage.S3 do
   end
 
   defp build_signed_url(definition, version, file_and_scope, options) do
-    expires_in = Keyword.get(options, :expire_in, @default_expiry_time)
+    options = put_in options[:expire_in], Keyword.get(options, :expire_in, @default_expiry_time)
+    options = put_in options[:virtual_host], virtual_host
     config = ExAws.Config.new(:s3, Application.get_all_env(:ex_aws))
-    {:ok, url} = ExAws.S3.presigned_url(config, :get, bucket, s3_key(definition, version, file_and_scope), [expires_in: expires_in, virtual_host: virtual_host])
+    {:ok, url} = ExAws.S3.presigned_url(config, :get, bucket, s3_key(definition, version, file_and_scope), options)
     url
   end
 


### PR DESCRIPTION
This allows to pass options to definition.url (signed). For my use case it was the ability to pass the query param `response-content-disposition` to override the header `Content-Disposition`. There are a bunch more query params that can override headers.
