### PR TITLE
Bug fix: Deal with spaces in file names

### DIFF
--- a/lib/arc/transformations/convert.ex
+++ b/lib/arc/transformations/convert.ex
@@ -1,7 +1,7 @@
 defmodule Arc.Transformations.Convert do
   def apply(cmd, file, args) do
     new_path = Arc.File.generate_temporary_path(file)
-    args     = if is_function(args), do: args.(file.path, new_path), else: "#{file.path} #{args} #{new_path}"
+    args     = if is_function(args), do: args.(file.path, new_path), else: [file.path | (String.split(args, " ") ++ [new_path])]
     program  = to_string(cmd)
 
     ensure_executable_exists!(program)


### PR DESCRIPTION
This change splits the string command line into a list based on spaces so that the file paths can contain spaces.
