### PR TITLE
Check before prepending “/“ to local storage URLs

### DIFF
--- a/lib/arc/storage/local.ex
+++ b/lib/arc/storage/local.ex
@@ -14,7 +14,13 @@ defmodule Arc.Storage.Local do
   end
 
   def url(definition, version, file_and_scope, _options \\ []) do
-    "/" <> build_local_path(definition, version, file_and_scope)
+    local_path = build_local_path(definition, version, file_and_scope)
+
+    if String.starts_with?(local_path, "/") do
+      local_path
+    else
+      "/" <> local_path
+    end
   end
 
   def delete(definition, version, file_and_scope) do


### PR DESCRIPTION
Sometimes the storage directory already is an absolute path. For example, we use `priv/uploads` in dev and `/uploads` in prod (outside of the app path where nginx serves the files). In prod, Arc is generating URLs that start like `//uploads/`, which leads to [unfortunate workarounds](https://github.com/thechangelog/changelog.com/blob/master/web/views/person_view.ex#L9).

This commit adds a check and only prepends the "/" if it isn't there already.

_(Thanks for Arc! It powers every episode uploaded on the entire [Changelog](https://changelog.com) network)_
