### PR TITLE
allow asynchronous version storage to be toggled

### DIFF
--- a/lib/arc/actions/store.ex
+++ b/lib/arc/actions/store.ex
@@ -26,10 +26,16 @@ defmodule Arc.Actions.Store do
   end
 
   defp put_versions(definition, {file, scope}) do
-    definition.__versions
-    |> Enum.map(fn(r)    -> async_put_version(definition, r, {file, scope}) end)
-    |> Enum.map(fn(task) -> Task.await(task, version_timeout) end)
-    |> handle_responses(file.file_name)
+    if definition.async do
+      definition.__versions
+      |> Enum.map(fn(r)    -> async_put_version(definition, r, {file, scope}) end)
+      |> Enum.map(fn(task) -> Task.await(task, version_timeout) end)
+      |> handle_responses(file.file_name)
+    else
+      definition.__versions
+      |> Enum.map(fn(version) -> put_version(definition, version, {file, scope}) end)
+      |> handle_responses(file.file_name)
+    end
   end
 
   defp handle_responses(responses, filename) do

--- a/lib/arc/definition/storage.ex
+++ b/lib/arc/definition/storage.ex
@@ -2,6 +2,7 @@ defmodule Arc.Definition.Storage do
   defmacro __using__(_) do
     quote do
       @acl :private
+      @async true
 
       def filename(_, {file, _}), do: Path.basename(file.file_name, Path.extname(file.file_name))
       def storage_dir(_, _), do: "uploads"
@@ -20,6 +21,7 @@ defmodule Arc.Definition.Storage do
     quote do
       def acl(_, _), do: @acl
       def s3_object_headers(_, _), do: []
+      def async, do: @async
     end
   end
 end


### PR DESCRIPTION
We have an uploader with 9 file versions defined, each of which requires an imagemagick `convert` transformation. Running the transformations in a container with 1GB of memory, we were consistently finding that the container would crash because it was running out of memory during file upload. We need to be able to keep our container resource requirements small.

Transformations are run asynchronously, so 9 instances of the `convert` executable were being run at the same time. As `convert` is a C library, the Erlang VM has no way of managing the amount of memory it will use. This PR helps overcome this by allowing uploader definitions to be configured to process versions synchronously.

This solved our problem and we've been using it successfully in production for over a month now. Do you think it's a useful extension of arc or would you recommend a different way of solving the problem we faced?