### PR TITLE
fix expire_in bug

### DIFF
--- a/lib/arc/storage/s3.ex
+++ b/lib/arc/storage/s3.ex
@@ -73,7 +73,10 @@ defmodule Arc.Storage.S3 do
   end
 
   defp build_signed_url(definition, version, file_and_scope, options) do
-    options = put_in options[:expire_in], Keyword.get(options, :expire_in, @default_expiry_time)
+    # previous arc argument was expire_in instead of expires_in
+    options = put_in options[:expires_in], Keyword.get(options, :expire_in, @default_expiry_time)
+    # if expires_in is found in options, use that instead
+    options = put_in options[:expires_in], Keyword.get(options, :expires_in, options[:expires_in])
     options = put_in options[:virtual_host], virtual_host
     config = ExAws.Config.new(:s3, Application.get_all_env(:ex_aws))
     {:ok, url} = ExAws.S3.presigned_url(config, :get, bucket, s3_key(definition, version, file_and_scope), options)


### PR DESCRIPTION
Sorry, just found a bug I introduced myself 😱😱😱

In the previous version of `arc` you could set the option `expire_in` which would be converted to the expires_in option in `ex_aws`. I added a pull-request to be able to pass along more options, but I didn't convert `expire_in => expires_in` but simply `expire_in => expire_in`. This will cause `expire_in` not to work anymore, (but passing `expires_in` does). This update makes them both work again. (`expires_in` takes precedence over `expire_in`).

I would suggest to use `expires_in` in the documentation to be consistent with `ex_aws`.