### PR TITLE
update required dependencies for S3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ defp deps do
     arc: "~> 0.6.0",
 
     # If using Amazon S3:
-    ex_aws: "~> 1.0.0-rc3",
-    hackney: "~> 1.5",
+    ex_aws: "~> 1.0.0",
     poison: "~> 2.0",
     sweet_xml: "~> 0.5"
   ]


### PR DESCRIPTION
ex_aws 1.0 is released so don't link to the release candidate. ex_aws also declares its own dependency on hackney 