### PR TITLE
Fixed the deprecation warnings in the generator

### DIFF
--- a/lib/mix/tasks/g.ex
+++ b/lib/mix/tasks/g.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Arc do
   defmodule G do
     use Mix.Task
     import Mix.Generator
-    import Mix.Utils, only: [camelize: 1, underscore: 1]
+    import Macro, only: [camelize: 1, underscore: 1]
 
     @shortdoc "For Arc definition generation code"
 


### PR DESCRIPTION
`Mix.Utils.camelize` is dreprecated.