### PR TITLE
Fix remaining Elixir warnings

### DIFF
--- a/lib/arc/actions/store.ex
+++ b/lib/arc/actions/store.ex
@@ -29,7 +29,7 @@ defmodule Arc.Actions.Store do
     if definition.async do
       definition.__versions
       |> Enum.map(fn(r)    -> async_put_version(definition, r, {file, scope}) end)
-      |> Enum.map(fn(task) -> Task.await(task, version_timeout) end)
+      |> Enum.map(fn(task) -> Task.await(task, version_timeout()) end)
       |> handle_responses(file.file_name)
     else
       definition.__versions

--- a/lib/arc/file.ex
+++ b/lib/arc/file.ex
@@ -5,7 +5,7 @@ defmodule Arc.File do
     extension = Path.extname((file && file.path) || "")
 
     file_name =
-      :crypto.rand_bytes(20)
+      :crypto.strong_rand_bytes(20)
       |> Base.encode32()
       |> Kernel.<>(extension)
 


### PR DESCRIPTION
Compiling the recent 0.7.0 release (and master) still put out a couple warnings:

```
warning: variable "version_timeout" does not exist and is being expanded to "version_timeout()", please use parentheses to remove the ambiguity or change the variable name
  lib/arc/actions/store.ex:32

warning: crypto:rand_bytes/1 is deprecated and will be removed in a future release; use crypto:strong_rand_bytes/1
  lib/arc/file.ex:8
```