### PR TITLE
Add arc_gcs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Arc ships with integrations for Local Storage and S3.  Alternative storage provi
 
 * **Rackspace** - https://github.com/lokalebasen/arc_rackspace
 * **Manta** - https://github.com/onyxrev/arc_manta
+* **Google Cloud Storage** - https://github.com/martide/arc_gcs
 
 ### Usage with Ecto
 


### PR DESCRIPTION
Hi, 

We built a Google Cloud Storage engine for Arc and would like to add it to the README. 

Thanks
Sam