### PR TITLE
Reverted behaviour of asset_host so that false uses the default host

### DIFF
--- a/lib/arc/storage/s3.ex
+++ b/lib/arc/storage/s3.ex
@@ -93,10 +93,11 @@ defmodule Arc.Storage.S3 do
   end
 
   defp host do
-    host_url = Application.get_env(:arc, :asset_host, default_host())
+    host_url = Application.get_env(:arc, :asset_host) || false
 
     case host_url do
       {:system, env_var} when is_binary(env_var) -> System.get_env(env_var)
+      false -> default_host()
       url -> url
     end
   end

--- a/test/storage/s3_test.exs
+++ b/test/storage/s3_test.exs
@@ -140,6 +140,10 @@ defmodule ArcTest.Storage.S3 do
       System.put_env("ARC_ASSET_HOST", custom_asset_host)
       assert "#{custom_asset_host}/arctest/uploads/image.png" == DummyDefinition.url(@img)
     end
+
+    with_env :arc, :asset_host, false, fn ->
+      assert "https://s3.amazonaws.com/#{env_bucket()}/arctest/uploads/image.png" == DummyDefinition.url(@img)
+    end
   end
 
   @tag :s3


### PR DESCRIPTION
Hi,

This fixes an issue we ran into when upgrading from arc 0.5.0 to 0.8.1. We were previously setting asset_host to false or a string in our exrm release configurations. However, with the upgrade to 0.8.1, it looks like if you set asset_host to *anything* then it will try to use it as the host url. This is frustrating, because we have to completely remove the asset_host configuration variable from our exrm release schema in order to get the default_host behavior.

I think that https://github.com/stavro/arc/commit/e5da42ce3722ed3c22cb41444ac0220fd63c0479 changed the behavior of the asset_host variable so that a value of 'false' no longer uses the default_host. This PR just allows you to set asset_host to 'false' to enable the default_host behavior.