### PR TITLE
Allows skipping files during the transformation

### DIFF
--- a/lib/arc/actions/store.ex
+++ b/lib/arc/actions/store.ex
@@ -56,6 +56,7 @@ defmodule Arc.Actions.Store do
   defp put_version(definition, version, {file, scope}) do
     case Arc.Processor.process(definition, version, {file, scope}) do
       {:error, error} -> {:error, error}
+      {:skip} -> {:skip}
       {:ok, file} ->
         file_name = Arc.Definition.Versioning.resolve_file_name(definition, version, {file, scope})
         file      = %Arc.File{file | file_name: file_name}

--- a/lib/arc/processor.ex
+++ b/lib/arc/processor.ex
@@ -6,6 +6,7 @@ defmodule Arc.Processor do
 
   defp apply_transformation(file, :noaction), do: {:ok, file}
   defp apply_transformation(file, {:noaction}), do: {:ok, file} # Deprecated
+  defp apply_transformation(_file, :skip), do: {:skip}
   defp apply_transformation(file, {cmd, conversion, _}) do
     apply_transformation(file, {cmd, conversion})
   end


### PR DESCRIPTION
Use case :

I want all media files to be handles through arc, but images need to
have 3 versions (:original, :thumb, :viewable) and videos simply need to
have :original and :thumb (since :viewable is just a low-res image that
acts as a place holder). Maybe I'm creating problems for myself by
handling videos and pictures all in one, but I feel like this could be a
nice addition.

Still quite new to the elixir world, so I may not have used a proper
technique to do the test. It doesn't feel quite right.