### PR TITLE
Update to skip uploading all files if any of the files fail

### DIFF
--- a/lib/arc/actions/store.ex
+++ b/lib/arc/actions/store.ex
@@ -28,14 +28,24 @@ defmodule Arc.Actions.Store do
   defp put_versions(definition, {file, scope}) do
     if definition.async do
       definition.__versions
-      |> Enum.map(fn(r)    -> async_put_version(definition, r, {file, scope}) end)
+      |> Enum.map(fn(r)    -> async_process_version(definition, r, {file, scope}) end)
+      |> Enum.map(fn(task) -> Task.await(task, version_timeout()) end)
+      |> ensure_all_success
+      |> Enum.map(fn({v, r})    -> async_put_version(definition, v, {r, scope}) end)
       |> Enum.map(fn(task) -> Task.await(task, version_timeout()) end)
       |> handle_responses(file.file_name)
     else
       definition.__versions
-      |> Enum.map(fn(version) -> put_version(definition, version, {file, scope}) end)
+      |> Enum.map(fn(version) -> process_version(definition, version, {file, scope}) end)
+      |> ensure_all_success
+      |> Enum.map(fn({version, result}) -> put_version(definition, version, {result, scope}) end)
       |> handle_responses(file.file_name)
     end
+  end
+
+  defp ensure_all_success(responses) do
+    errors = Enum.filter(responses, fn({version, resp}) -> elem(resp, 0) == :error end)
+    if Enum.empty?(errors), do: responses, else: errors
   end
 
   defp handle_responses(responses, filename) do
@@ -47,19 +57,30 @@ defmodule Arc.Actions.Store do
     Application.get_env(:arc, :version_timeout) || 15_000
   end
 
-  defp async_put_version(definition, version, {file, scope}) do
+  defp async_process_version(definition, version, {file, scope}) do
     Task.async(fn ->
-      put_version(definition, version, {file, scope})
+      process_version(definition, version, {file, scope})
     end)
   end
 
-  defp put_version(definition, version, {file, scope}) do
-    case Arc.Processor.process(definition, version, {file, scope}) do
+  defp async_put_version(definition, version, {result, scope}) do
+    Task.async(fn ->
+      put_version(definition, version, {result, scope})
+    end)
+  end
+
+  defp process_version(definition, version, {file, scope}) do
+    {version, Arc.Processor.process(definition, version, {file, scope})}
+  end
+
+  defp put_version(definition, version, {result, scope}) do
+    case result do
       {:error, error} -> {:error, error}
       {:ok, file} ->
         file_name = Arc.Definition.Versioning.resolve_file_name(definition, version, {file, scope})
         file      = %Arc.File{file | file_name: file_name}
-        definition.__storage.put(definition, version, {file, scope})
+        result = definition.__storage.put(definition, version, {file, scope})
+        result
     end
   end
 end

--- a/test/storage/local_test.exs
+++ b/test/storage/local_test.exs
@@ -1,6 +1,7 @@
 defmodule ArcTest.Storage.Local do
   use ExUnit.Case
   @img "test/support/image.png"
+  @badimg "test/support/invalid_image.png"
 
   setup_all do
     File.mkdir_p("arctest/uploads")
@@ -12,6 +13,7 @@ defmodule ArcTest.Storage.Local do
 
 
   defmodule DummyDefinition do
+    use Arc.Actions.Store
     use Arc.Definition.Storage
     use Arc.Actions.Url
     use Arc.Definition.Storage
@@ -49,5 +51,15 @@ defmodule ArcTest.Storage.Local do
   test "encoded url" do
     url = Arc.Storage.Local.url(DummyDefinition, :original, {Arc.File.new(%{binary: "binary", filename: "binary file.png"}), nil})
     assert "/arctest/uploads/original-binary%20file.png" == url
+  end
+
+  test "if one transform fails, they all fail" do
+    filepath = @badimg
+    [filename] = String.split(@img, "/") |> Enum.reverse |> Enum.take(1)
+    assert File.exists?(filepath)
+    DummyDefinition.store(filepath)
+
+    assert !File.exists?("arctest/uploads/original-#{filename}")
+    assert !File.exists?("arctest/uploads/1/thumb-#{filename}")
   end
 end

--- a/test/support/invalid_image.png
+++ b/test/support/invalid_image.png
@@ -1,0 +1,1 @@
+This is not a PNG file.


### PR DESCRIPTION
We recently ran into an issue where we had multiple versions of a file and if one of the conversions fails (for example, if it is not actually an image, but a text file with an incorrect file extension) then some of the uploads will work (those which have no `:noaction`) but all the conversions will fail.

This results in overwriting `:original` versions despite returning an error code to the user, resulting in inconsistent states and unexpected side effects.

This PR adds a test for this behavior, and updates to run the processing of files separately from the uploading so that we may stop uploads if any of the conversions fail.