### PR TITLE
Remove ambiguous `path identifier` in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ user = Repo.get! User, 1
 user = Repo.get!(User, 1)
 {:ok, original_filename} = Avatar.store({"/Images/me.png", user})
 user = Repo.get!(User, 1)
-:ok = Avatar.delete({user.avatar.file_name, user})
+:ok = Avatar.delete({user.avatar, user})
 ```
 
 ## Url Generation

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Example usage as general file store:
 Avatar.store("/path/to/my/file.png") #=> {:ok, "file.png"}
 
 # Store any remotely accessible file
-Avatar.store("http://example.com/image.png") #=> {:ok, "file.png"}
+Avatar.store("http://example.com/file.png") #=> {:ok, "file.png"}
 
 # Store a file directly from a `%Plug.Upload{}`
 Avatar.store(%Plug.Upload{filename: "file.png", path: "/a/b/c"}) #=> {:ok, "file.png"}
@@ -444,13 +444,18 @@ Example:
 
 ```elixir
 # Without a scope:
-{:ok, path} = DummyDefinition.store("/Images/me.png")
-:ok = DummyDefinition.delete(path)
+{:ok, original_filename} = Avatar.store("/Images/me.png")
+:ok = Avatar.delete(original_filename)
 
 # With a scope:
 user = Repo.get! User, 1
-{:ok, path} = DummyDefinition.store({"/Images/me.png", user})
-:ok = DummyDefinition.delete({path, user})
+{:ok, original_filename} = Avatar.store({"/Images/me.png", user})
+:ok = Avatar.delete({original_filename, user})
+# or
+user = Repo.get!(User, 1)
+{:ok, original_filename} = Avatar.store({"/Images/me.png", user})
+user = Repo.get!(User, 1)
+:ok = Avatar.delete({user.avatar.file_name, user})
 ```
 
 ## Url Generation


### PR DESCRIPTION
In README, there're some confusing meanings of filename; `filename`, `file_name`, `path`, `path identifier`. And `path identifier` isn't well understandable nor used any other sections in arc docs.

AFAIK, kinds of filename are;
- source_filename : file name of source file except path. (ex. `file.png`)
- source_path : source path. (ex. `/path/to/my/`)
- source_path_filename : file name with source path. (ex. `/path/to/my/file.png`)
- target_filename : name of stored file. (ex. `newfile.png`)
- target_path : target path. (ex. `/uploads/users/avatars/`)
- target_path_filename : file name with target path. (ex. `/uploads/users/avatars/newfile.png`)

Since the `delete/1` receives either `source filename` or `target filename`, it'd better to describe which filename to use as a parameter.

In addition, some minor changes;
- Fix typo; `image.png` with `file.png`.
- Replace `DummyDefinition` with `Avatar`.
