### PR TITLE
Remove unused variable to fix compiler warning

### DIFF
--- a/lib/arc/actions/store.ex
+++ b/lib/arc/actions/store.ex
@@ -44,7 +44,7 @@ defmodule Arc.Actions.Store do
   end
 
   defp ensure_all_success(responses) do
-    errors = Enum.filter(responses, fn({version, resp}) -> elem(resp, 0) == :error end)
+    errors = Enum.filter(responses, fn({_version, resp}) -> elem(resp, 0) == :error end)
     if Enum.empty?(errors), do: responses, else: errors
   end
 


### PR DESCRIPTION
`warning: variable "version" is unused
  lib/arc/actions/store.ex:47` when compiling.

Simple underscore ignore.