### PR TITLE
Bypass delete on skipped versions

### DIFF
--- a/lib/arc/actions/delete.ex
+++ b/lib/arc/actions/delete.ex
@@ -2,7 +2,7 @@ defmodule Arc.Actions.Delete do
   defmacro __using__(_) do
     quote do
       def delete(args), do: Arc.Actions.Delete.delete(__MODULE__, args)
-      
+
       defoverridable [{:delete, 1}]
     end
   end
@@ -40,6 +40,11 @@ defmodule Arc.Actions.Delete do
   end
 
   defp delete_version(definition, version, {file, scope}) do
-    definition.__storage.delete(definition, version, {file, scope})
+    conversion = definition.transform(version, {file, scope})
+    if conversion == :skip do
+      :ok
+    else
+      definition.__storage.delete(definition, version, {file, scope})
+    end
   end
 end

--- a/test/storage/local_test.exs
+++ b/test/storage/local_test.exs
@@ -13,9 +13,7 @@ defmodule ArcTest.Storage.Local do
 
 
   defmodule DummyDefinition do
-    use Arc.Actions.Store
-    use Arc.Definition.Storage
-    use Arc.Actions.Url
+    use Arc.Definition
 
     @acl :public_read
     def transform(:thumb, _), do: {:convert, "-strip -thumbnail 10x10"}
@@ -42,6 +40,11 @@ defmodule ArcTest.Storage.Local do
     :ok = Arc.Storage.Local.delete(DummyDefinition, :thumb, {%{file_name: "image.png"}, nil})
     refute File.exists?("arctest/uploads/original-image.png")
     refute File.exists?("arctest/uploads/1/thumb-image.png")
+  end
+
+  test "deleting when there's a skipped version" do
+    DummyDefinition.store(@img)
+    assert :ok = DummyDefinition.delete(@img)
   end
 
   test "save binary" do


### PR DESCRIPTION
Fixes #280 

When I added the functionality for skipped versions, I forgot to bypass when trying to delete a skipped version (since there is no actual file to delete)